### PR TITLE
feat(islands): optimize island detection and debounce logic

### DIFF
--- a/src/canvas/canvaskit/hooks/use-island-detection.ts
+++ b/src/canvas/canvaskit/hooks/use-island-detection.ts
@@ -1,10 +1,11 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import {
 	useIslandManagement,
 	useIslandDetectionOptions,
 } from "@store/island-hooks";
 import { useElements } from "@store/element-hooks";
 import { IslandDetector } from "../managers/island-detector";
+import type { BaseElement } from "@store/elements";
 
 /**
  * Hook to automatically detect islands when elements change
@@ -17,24 +18,82 @@ export const useIslandDetection = () => {
 	// Create island detector instance
 	const islandDetector = useMemo(() => new IslandDetector(), []);
 
-	// Detect islands when elements change
+	// Track previous elements for incremental detection
+	const prevElementsRef = useRef<BaseElement[]>([]);
+	const timeoutRef = useRef<number | null>(null);
+
+	// Optimized change detection
+	const hasSignificantChange = useMemo(() => {
+		const prev = prevElementsRef.current;
+
+		// Quick checks for obvious changes
+		if (prev.length !== elements.length) return true;
+		if (elements.length === 0) return prev.length > 0;
+
+		// Check if any element has significantly changed position or size
+		const threshold = 10; // pixels
+		for (let i = 0; i < elements.length; i++) {
+			const curr = elements[i];
+			if (!curr) continue;
+			const prevEl = prev.find((p) => p.id === curr.id);
+
+			if (!prevEl) return true; // New element
+
+			if (
+				Math.abs(curr.x - prevEl.x) > threshold ||
+				Math.abs(curr.y - prevEl.y) > threshold ||
+				Math.abs(curr.w - prevEl.w) > threshold ||
+				Math.abs(curr.h - prevEl.h) > threshold
+			) {
+				return true;
+			}
+		}
+
+		return false;
+	}, [elements]);
+
+	// Detect islands when elements change significantly
 	useEffect(() => {
+		// Clear existing timeout
+		if (timeoutRef.current) {
+			clearTimeout(timeoutRef.current);
+		}
+
 		if (elements.length === 0) {
 			detectIslands([]);
+			prevElementsRef.current = [];
 			return;
 		}
 
-		// Debounce island detection to avoid excessive computation
-		const timeoutId = setTimeout(() => {
+		// Only run detection if there are significant changes
+		if (!hasSignificantChange) {
+			return;
+		}
+
+		// Use adaptive debouncing - shorter delay for small datasets
+		const adaptiveDelay = Math.min(300, Math.max(50, elements.length * 2));
+
+		timeoutRef.current = setTimeout(() => {
 			const detectedIslands = islandDetector.detectIslands(
 				elements,
 				detectionOptions,
 			);
 			detectIslands(detectedIslands);
-		}, 300);
+			prevElementsRef.current = [...elements]; // Deep copy for comparison
+		}, adaptiveDelay) as unknown as number;
 
-		return () => clearTimeout(timeoutId);
-	}, [elements, detectionOptions, islandDetector, detectIslands]);
+		return () => {
+			if (timeoutRef.current) {
+				clearTimeout(timeoutRef.current);
+			}
+		};
+	}, [
+		elements,
+		detectionOptions,
+		islandDetector,
+		detectIslands,
+		hasSignificantChange,
+	]);
 
 	return {
 		isDetecting,

--- a/src/components/island-switcher/island-switcher.tsx
+++ b/src/components/island-switcher/island-switcher.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useMemo } from "react";
+import React, { useEffect, useRef, useMemo, useCallback } from "react";
 import { useIslandSwitcher, useIslands } from "@store/island-hooks";
 import { IslandPreviewGenerator } from "@canvas/canvaskit/managers/island-preview-generator";
 import "./island-switcher.css";
@@ -18,8 +18,19 @@ export const IslandSwitcher: React.FC = () => {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const carouselContainerRef = useRef<HTMLDivElement>(null);
 
-	// Create preview generator instance
+	// Create preview generator instance with cleanup
 	const previewGenerator = useMemo(() => new IslandPreviewGenerator(), []);
+
+	// Preview cache to avoid regenerating SVGs
+	const previewCache = useRef(new Map<string, string>());
+
+	// Clear cache and cleanup when component unmounts
+	useEffect(() => {
+		return () => {
+			previewCache.current.clear();
+			previewGenerator.destroy();
+		};
+	}, [previewGenerator]);
 
 	// Handle keyboard navigation
 	useEffect(() => {
@@ -79,6 +90,167 @@ export const IslandSwitcher: React.FC = () => {
 		return () => document.removeEventListener("mousedown", handleClickOutside);
 	}, [isOpen, closeSwitcher]);
 
+	// Generate cached preview for an island - MOVED BEFORE EARLY RETURNS
+	const getCachedPreview = useCallback(
+		(island: any) => {
+			if (!island || !island.elements) {
+				return previewGenerator.generatePlaceholderPreview(island, {
+					width: 120,
+					height: 80,
+				});
+			}
+
+			// Create cache key based on island content hash
+			const cacheKey = `${island.id}-${island.elementCount}-${JSON.stringify(island.bounds)}`;
+
+			// Check cache first
+			let previewUrl = previewCache.current.get(cacheKey);
+
+			if (!previewUrl) {
+				// Generate new preview - always try SVG first
+				try {
+					previewUrl = previewGenerator.generateSVGPreview(island, {
+						width: 120,
+						height: 80,
+					});
+
+					// Validate the SVG preview
+					if (
+						!previewUrl ||
+						previewUrl.length < 50 ||
+						!previewUrl.startsWith("data:image/svg+xml")
+					) {
+						throw new Error("Invalid SVG preview generated");
+					}
+
+					previewCache.current.set(cacheKey, previewUrl);
+				} catch (error) {
+					console.warn(
+						"SVG preview generation failed, using placeholder:",
+						error,
+					);
+					// Fallback to placeholder
+					previewUrl = previewGenerator.generatePlaceholderPreview(island, {
+						width: 120,
+						height: 80,
+					});
+					previewCache.current.set(cacheKey, previewUrl);
+				}
+
+				// Limit cache size to prevent memory issues
+				if (previewCache.current.size > 50) {
+					const firstKey = previewCache.current.keys().next().value;
+					if (firstKey) {
+						previewCache.current.delete(firstKey);
+					}
+				}
+			}
+
+			return previewUrl;
+		},
+		[previewGenerator],
+	);
+
+	// Render individual island item (memoized) - MOVED BEFORE EARLY RETURNS
+	const renderIslandItem = useCallback(
+		(index: number) => {
+			const island = islands[index];
+			if (!island) return null;
+
+			const previewUrl = getCachedPreview(island);
+
+			return (
+				<div
+					key={island.id}
+					className={`island-item ${index === currentIndex[0] ? "selected" : ""}`}
+					onClick={(e) => {
+						e.stopPropagation();
+						selectIsland(index);
+						confirmSelection();
+					}}
+				>
+					<div className="island-preview-container">
+						<img
+							src={previewUrl}
+							alt={`Island ${index + 1} preview`}
+							className="island-content-preview"
+							loading="lazy"
+						/>
+					</div>
+					<div className="island-name">
+						Island {index + 1} ({island.elementCount} elements)
+					</div>
+				</div>
+			);
+		},
+		[islands, currentIndex, selectIsland, confirmSelection, getCachedPreview],
+	);
+
+	// Memoized container width calculation for sliding window - MOVED BEFORE EARLY RETURNS
+	const containerWidth = useMemo(() => {
+		const itemOnlyWidth = 140; // Item width without gap
+		const gapWidth = 16; // Gap between items
+		const padding = 40; // Container padding (20px each side)
+
+		// Always show a fixed window size for consistent experience
+		const maxVisibleItems = Math.min(5, islands.length);
+
+		// For single item, use just the item width plus padding
+		if (islands.length === 1) {
+			return itemOnlyWidth + padding;
+		}
+
+		// Calculate width for the sliding window (shows up to maxVisibleItems)
+		const visibleItemsWidth = maxVisibleItems * itemOnlyWidth;
+		const visibleGapsWidth = Math.max(0, maxVisibleItems - 1) * gapWidth;
+
+		return visibleItemsWidth + visibleGapsWidth + padding;
+	}, [islands.length]);
+
+	// Memoized carousel style calculation with sliding window behavior - MOVED BEFORE EARLY RETURNS
+	const carouselStyle = useMemo(() => {
+		const itemWidth = 156; // 140px + 16px gap (140px item + 16px gap)
+		const itemOnlyWidth = 140; // actual item width without gap
+		const gapWidth = 16;
+		const totalCarouselWidth =
+			islands.length * itemOnlyWidth +
+			Math.max(0, islands.length - 1) * gapWidth;
+		const availableContainerWidth = containerWidth - 40; // Account for container padding (20px each side)
+
+		// Special case for single island - center it
+		if (islands.length === 1) {
+			return {
+				width: `${totalCarouselWidth}px`,
+				transform: `translateX(0px)`,
+				transition: "transform 0.2s ease-out",
+			};
+		}
+
+		// SLIDING WINDOW BEHAVIOR: Always center the selected item
+		const selectedItemCenter = currentIndex[0] * itemWidth + itemOnlyWidth / 2;
+		const containerCenter = availableContainerWidth / 2;
+
+		// Calculate offset to center the selected item
+		let offset = containerCenter - selectedItemCenter;
+
+		// For very few items, don't scroll if everything fits
+		if (totalCarouselWidth <= availableContainerWidth) {
+			// Center the entire carousel if it fits completely
+			offset = (availableContainerWidth - totalCarouselWidth) / 2;
+		} else {
+			// Apply bounds to prevent showing empty space at edges
+			const maxOffset = 0; // Don't scroll past the beginning
+			const minOffset = availableContainerWidth - totalCarouselWidth; // Don't scroll past the end
+			offset = Math.max(minOffset, Math.min(maxOffset, offset));
+		}
+
+		return {
+			width: `${totalCarouselWidth}px`,
+			transform: `translateX(${offset}px)`,
+			transition: "transform 0.2s ease-out", // Smooth sliding animation
+		};
+	}, [islands.length, currentIndex, containerWidth]);
+
 	if (!isOpen[0]) {
 		return null;
 	}
@@ -104,146 +276,16 @@ export const IslandSwitcher: React.FC = () => {
 		);
 	}
 
-	// Render individual island item
-	const renderIslandItem = (index: number) => {
-		const island = islands[index];
-		if (!island) return null;
-
-		let previewContent;
-
-		try {
-			const svgUrl = previewGenerator.generateSVGPreview(island, {
-				width: 120,
-				height: 80,
-			});
-
-			previewContent = (
-				<img
-					src={svgUrl}
-					alt={`Island ${index + 1} preview`}
-					className="island-content-preview"
-					onError={(e) => {
-						// Try to show placeholder on error
-						const target = e.target as HTMLImageElement;
-						const placeholderUrl = previewGenerator.generatePlaceholderPreview(
-							island,
-							{
-								width: 120,
-								height: 80,
-							},
-						);
-						target.src = placeholderUrl;
-					}}
-				/>
-			);
-		} catch (error) {
-			// Fallback to placeholder
-			const placeholderUrl = previewGenerator.generatePlaceholderPreview(
-				island,
-				{
-					width: 120,
-					height: 80,
-				},
-			);
-			previewContent = (
-				<img
-					src={placeholderUrl}
-					alt={`Island ${index + 1} preview (placeholder)`}
-					className="island-content-preview"
-				/>
-			);
-		}
-
-		return (
-			<div
-				key={island.id}
-				className={`island-item ${index === currentIndex[0] ? "selected" : ""}`}
-				onClick={(e) => {
-					e.stopPropagation();
-					selectIsland(index);
-					confirmSelection();
-				}}
-			>
-				<div className="island-preview-container">{previewContent}</div>
-				<div className="island-name">
-					Island {index + 1} ({island.elementCount} elements)
-				</div>
-			</div>
-		);
-	};
-
-	// Calculate container width based on number of islands
-	const getContainerWidth = () => {
-		const itemWidth = 156; // 140px + 16px gap
-		const padding = 40; // Container padding (20px each side)
-		const maxVisibleItems = 5;
-		const visibleItems = Math.min(islands.length, maxVisibleItems);
-
-		// For single item, use just the item width plus padding
-		if (visibleItems === 1) {
-			return itemWidth + padding;
-		}
-
-		// For multiple items, calculate based on visible items
-		const gapWidth = 16; // gap between items
-		const totalItemsWidth = visibleItems * 140; // item width without gap
-		const totalGapsWidth = (visibleItems - 1) * gapWidth;
-
-		return totalItemsWidth + totalGapsWidth + padding;
-	};
-
-	// Calculate carousel positioning
-	const getCarouselStyle = () => {
-		const itemWidth = 156; // 140px + 16px gap
-		const padding = 20; // padding from CSS
-		const totalCarouselWidth = islands.length * itemWidth;
-		const containerWidth = getContainerWidth() - padding * 2; // Available width inside container
-
-		// Special case for single island - no offset needed since container is sized to fit
-		if (islands.length === 1) {
-			return {
-				width: `${totalCarouselWidth}px`,
-				transform: `translateX(0px)`,
-			};
-		}
-
-		// For multiple islands, use carousel logic
-		const maxVisibleItems = 5;
-
-		if (islands.length <= maxVisibleItems) {
-			// Show all islands centered - no offset needed since container is sized to content
-			return {
-				width: `${totalCarouselWidth}px`,
-				transform: `translateX(0px)`,
-			};
-		}
-
-		// More than 5 islands - use scrolling carousel
-		const currentItemCenter = currentIndex[0] * itemWidth + itemWidth / 2;
-		const containerCenter = containerWidth / 2;
-		let offset = containerCenter - currentItemCenter;
-
-		// Apply bounds to prevent over-scrolling
-		const maxOffset = padding;
-		const minOffset = containerWidth - totalCarouselWidth + padding;
-		offset = Math.max(minOffset, Math.min(maxOffset, offset));
-
-		return {
-			width: `${totalCarouselWidth}px`,
-			transform: `translateX(${offset}px)`,
-		};
-	};
-
 	return (
 		<div className="island-switcher-overlay">
 			<div
 				className="island-switcher-container"
 				ref={containerRef}
-				style={{ width: `${getContainerWidth()}px` }}
+				style={{ width: `${containerWidth}px` }}
 			>
 				<div className="island-switcher-strip">
 					<div ref={carouselContainerRef} className="island-carousel-container">
-						<div className="island-carousel" style={getCarouselStyle()}>
+						<div className="island-carousel" style={carouselStyle}>
 							{islands.map((_island, index) => renderIslandItem(index))}
 						</div>
 					</div>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -9,33 +9,33 @@ import ptLocale from "./locales/pt.json";
 
 // Initialize i18n with all locales
 i18n
-  .use(LanguageDetector)
-  .use(initReactI18next)
-  .init({
-    fallbackLng: "en",
-    debug: false,
-    partialBundledLanguages: true,
+	.use(LanguageDetector)
+	.use(initReactI18next)
+	.init({
+		fallbackLng: "en",
+		debug: false,
+		partialBundledLanguages: true,
 
-    interpolation: {
-      escapeValue: false, // React already escapes values
-    },
+		interpolation: {
+			escapeValue: false, // React already escapes values
+		},
 
-    detection: {
-      order: ["localStorage", "navigator", "htmlTag"],
-      caches: ["localStorage"],
-    },
+		detection: {
+			order: ["localStorage", "navigator", "htmlTag"],
+			caches: ["localStorage"],
+		},
 
-    resources: {
-      en: {
-        translation: enLocale,
-      },
-      fr: {
-        translation: frLocale,
-      },
-      pt: {
-        translation: ptLocale,
-      },
-    },
-  });
+		resources: {
+			en: {
+				translation: enLocale,
+			},
+			fr: {
+				translation: frLocale,
+			},
+			pt: {
+				translation: ptLocale,
+			},
+		},
+	});
 
 export default i18n;

--- a/src/store/island-atoms.ts
+++ b/src/store/island-atoms.ts
@@ -51,29 +51,32 @@ export const currentIslandIndexAtom = atom((get) => {
 // Island switcher navigation
 export const nextIslandAtom = atom(null, (get, set) => {
 	const islands = get(islandsAtom);
-	const currentIndex = get(currentIslandIndexAtom);
-
 	if (islands.length === 0) return;
 
-	const nextIndex = (currentIndex + 1) % islands.length;
+	// Get the current switcher index directly to avoid circular dependency
+	const currentSwitcherIndex = get(islandSwitcherIndexAtom);
+	const nextIndex = (currentSwitcherIndex + 1) % islands.length;
 	const nextIsland = islands[nextIndex];
+
 	if (nextIsland) {
-		set(selectedIslandIdAtom, nextIsland.id);
 		set(islandSwitcherIndexAtom, nextIndex);
+		// Don't immediately update selectedIslandIdAtom - let the user confirm first
 	}
 });
 
 export const previousIslandAtom = atom(null, (get, set) => {
 	const islands = get(islandsAtom);
-	const currentIndex = get(currentIslandIndexAtom);
-
 	if (islands.length === 0) return;
 
-	const prevIndex = currentIndex <= 0 ? islands.length - 1 : currentIndex - 1;
+	// Get the current switcher index directly to avoid circular dependency
+	const currentSwitcherIndex = get(islandSwitcherIndexAtom);
+	const prevIndex =
+		currentSwitcherIndex <= 0 ? islands.length - 1 : currentSwitcherIndex - 1;
 	const prevIsland = islands[prevIndex];
+
 	if (prevIsland) {
-		set(selectedIslandIdAtom, prevIsland.id);
 		set(islandSwitcherIndexAtom, prevIndex);
+		// Don't immediately update selectedIslandIdAtom - let the user confirm first
 	}
 });
 
@@ -108,11 +111,14 @@ export const openIslandSwitcherAtom = atom(null, (get, set) => {
 	// Set initial selection to current island or first island (only if islands exist)
 	if (islands.length > 0) {
 		const currentIsland = get(selectedIslandIdAtom);
-		const initialIndex = currentIsland
-			? islands.findIndex((i) => i.id === currentIsland)
-			: 0;
+		let initialIndex = 0;
 
-		set(islandSwitcherIndexAtom, Math.max(0, initialIndex));
+		if (currentIsland) {
+			const foundIndex = islands.findIndex((i) => i.id === currentIsland);
+			initialIndex = foundIndex >= 0 ? foundIndex : 0;
+		}
+
+		set(islandSwitcherIndexAtom, initialIndex);
 	} else {
 		// Set to 0 for empty state
 		set(islandSwitcherIndexAtom, 0);

--- a/src/utils/island-keyboard-shortcuts.ts
+++ b/src/utils/island-keyboard-shortcuts.ts
@@ -106,13 +106,17 @@ export const useIslandKeyboardShortcuts = () => {
 
 			// When Cmd+Shift is released, travel to selected island and close switcher
 			if (event.key === "Meta" || event.key === "Shift") {
-				if (islands.length > 0) {
+				if (
+					islands.length > 0 &&
+					currentIndex[0] >= 0 &&
+					currentIndex[0] < islands.length
+				) {
 					const selectedIsland = islands[currentIndex[0]];
 					if (selectedIsland) {
 						travelToIsland(selectedIsland);
 					}
-					closeSwitcher();
 				}
+				closeSwitcher();
 			}
 		},
 		[hasIslands, isOpen, islands, currentIndex, travelToIsland, closeSwitcher],


### PR DESCRIPTION
Improve island detection to run only on significant element and to adaptively. Add prev-elements and timeout refs to avoid unnecessary full recalculations, compare positions/sizes with a threshold, and use a shorter adaptive delay for smaller datasets. This reduces CPU usage and prevents excessive re-detection during rapid UI updates.

chore(i18n): normalize indentation in i18n initialization

Reformat i18n initialization indenting for consistency (no functional change).

fix(island-switcher): avoid circular atom dependency and UX change

Replace reliance on currentIslandIndexAtom with islandSwitcherIndexAtom to prevent a potential circular dependency. Update next/previous island behavior to only change the switcher index and defer updating the selected island id so the user can confirm the switch.