### PR TITLE
docs: fix README tagline punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
   <img src=".github/assets/clise.png" alt="Clise Logo" width="1420" height="1200">
-  <p>A high-performance design canvas built with React and CanvasKit-WASM</p>
+  <p>A high-performance design canvas built with React and CanvasKit-WASM.</p>
 </div>
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
Add a missing period at the end of the README project description to ensure consistent sentence punctuation and improve presentation on the project landing page. This is a small editorial change with no code impact.