### PR TITLE
feat(smart-guides): avoid snapping when moving from guides

### DIFF
--- a/src/canvas/canvaskit/hooks/use-canvas-mouse-handlers.ts
+++ b/src/canvas/canvaskit/hooks/use-canvas-mouse-handlers.ts
@@ -696,6 +696,7 @@ export const useCanvasMouseHandlers = ({
 							elements,
 							selectedElementIds: selection,
 							tolerance: smartGuides.tolerance,
+							previousPosition: smartGuides.previousPosition || undefined,
 						},
 					);
 
@@ -707,9 +708,12 @@ export const useCanvasMouseHandlers = ({
 					});
 					smartGuides.setIsSnapping(snapResult.guides.length > 0);
 
-					// Use snapped coordinates
+					// Use snapped coordinates - simple like the demo
 					finalDeltaX = snapResult.snapX - draggedElement.x;
 					finalDeltaY = snapResult.snapY - draggedElement.y;
+
+					// Update previous position for next frame
+					smartGuides.setPreviousPosition({ x: targetX, y: targetY });
 				}
 			} else {
 				// Clear guides when not dragging or multiple elements selected

--- a/src/panels/file.tsx
+++ b/src/panels/file.tsx
@@ -5,7 +5,6 @@ import {
 	Menu,
 	Plus,
 	Save,
-	Ruler,
 } from "lucide-react";
 import { useToast } from "../components/ToastProvider";
 import { useTranslation } from "react-i18next";
@@ -15,7 +14,6 @@ import { useEffect, useRef, useState } from "react";
 import { LanguageSwitcher } from "../components/LanguageSwitcher";
 import { ThemeToggle } from "../components/ThemeToggle";
 import { useFileOperations } from "../store/file-hooks";
-import { useSmartGuidesEnabled } from "../store/smart-guides-hooks";
 
 export function FilePanel() {
 	const { t } = useTranslation();
@@ -24,7 +22,6 @@ export function FilePanel() {
 	const { exportAll, importFile, newDocument } = useFileOperations();
 	const toast = useToast();
 	const confirmModal = useConfirm();
-	const [smartGuidesEnabled, setSmartGuidesEnabled] = useSmartGuidesEnabled();
 
 	// Close dropdown when clicking outside
 	useEffect(() => {
@@ -114,21 +111,6 @@ export function FilePanel() {
 						<button className="dropdown-item" onClick={handleExport}>
 							<Download size={16} />
 							<span>{t("file.export", "Export")}</span>
-						</button>
-						<div className="dropdown-separator" />
-						<button
-							className="dropdown-item"
-							onClick={() => {
-								setSmartGuidesEnabled(!smartGuidesEnabled);
-								setIsOpen(false);
-							}}
-						>
-							<Ruler size={16} />
-							<span>
-								{smartGuidesEnabled
-									? t("file.disableSmartGuides", "Disable Smart Guides")
-									: t("file.enableSmartGuides", "Enable Smart Guides")}
-							</span>
 						</button>
 						<div className="dropdown-separator" />
 						<div className="dropdown-item language-switcher-item">

--- a/src/store/smart-guides-atoms.ts
+++ b/src/store/smart-guides-atoms.ts
@@ -2,7 +2,7 @@ import { atom } from "jotai";
 
 // Smart guides state atoms
 export const smartGuidesEnabledAtom = atom<boolean>(true);
-export const snapToleranceAtom = atom<number>(10); // Pixels within which snapping occurs
+export const snapToleranceAtom = atom<number>(2); // Pixels within which snapping occurs
 
 // Guide line data
 export interface GuideLine {
@@ -19,3 +19,6 @@ export const snapOffsetAtom = atom<{ x: number; y: number }>({ x: 0, y: 0 });
 
 // Whether we're currently snapping to guides
 export const isSnappingAtom = atom<boolean>(false);
+
+// Previous position for snap escape detection
+export const previousPositionAtom = atom<{ x: number; y: number } | null>(null);

--- a/src/store/smart-guides-hooks.ts
+++ b/src/store/smart-guides-hooks.ts
@@ -5,6 +5,7 @@ import {
 	activeGuidesAtom,
 	snapOffsetAtom,
 	isSnappingAtom,
+	previousPositionAtom,
 	type GuideLine,
 } from "./smart-guides-atoms";
 
@@ -13,6 +14,7 @@ export const useSnapTolerance = () => useAtom(snapToleranceAtom);
 export const useActiveGuides = () => useAtom(activeGuidesAtom);
 export const useSnapOffset = () => useAtom(snapOffsetAtom);
 export const useIsSnapping = () => useAtom(isSnappingAtom);
+export const usePreviousPosition = () => useAtom(previousPositionAtom);
 
 // Composite hook for smart guides functionality
 export const useSmartGuides = () => {
@@ -21,11 +23,13 @@ export const useSmartGuides = () => {
 	const [activeGuides, setActiveGuides] = useActiveGuides();
 	const [snapOffset, setSnapOffset] = useSnapOffset();
 	const [isSnapping, setIsSnapping] = useIsSnapping();
+	const [previousPosition, setPreviousPosition] = usePreviousPosition();
 
 	const clearGuides = () => {
 		setActiveGuides([]);
 		setSnapOffset({ x: 0, y: 0 });
 		setIsSnapping(false);
+		setPreviousPosition(null);
 	};
 
 	const addGuide = (guide: GuideLine) => {
@@ -47,6 +51,8 @@ export const useSmartGuides = () => {
 		setSnapOffset,
 		isSnapping,
 		setIsSnapping,
+		previousPosition,
+		setPreviousPosition,
 		clearGuides,
 		addGuide,
 		setGuides,


### PR DESCRIPTION
Add heuristics to SmartGuidesManager to reduce unwanted snapping when the user is actively moving away from a snap point. Accept a new optional previousPosition dependency and compute a simple movement distance to determine whether the pointer is moving away. When moving away, only apply snap when the element is very close (<= 50% of the tolerance), otherwise skip snapping. This logic is applied for both horizontal and vertical guide checks.

Also remove unused smart-guides toggle UI from the FilePanel: drop the Ruler import, the useSmartGuidesEnabled hook usages, and related menu items to simplify the file menu.

Motivation: prevent jarring or counterintuitive snaps while users drag elements past guide lines and intend to continue moving away. This improves drag UX by making snapping less aggressive while retreating.