### PR TITLE
fix: conditional hook calls

### DIFF
--- a/src/components/ConfirmProvider.tsx
+++ b/src/components/ConfirmProvider.tsx
@@ -30,12 +30,11 @@ const ConfirmContext = createContext<ConfirmContextType | undefined>(undefined);
 const ConfirmOverlayBase: React.FC<
 	WithTranslation & { state: InternalState; onClose: (v: boolean) => void }
 > = ({ state, onClose, t }) => {
-	if (!state) return null;
-	const { title, message, confirmText, cancelText, id } = state;
 	const modalRef = useRef<HTMLDivElement | null>(null);
 
 	// Focus management + trap
 	useEffect(() => {
+		if (!state) return;
 		const container = modalRef.current;
 		if (!container) return;
 
@@ -73,7 +72,11 @@ const ConfirmOverlayBase: React.FC<
 		};
 		document.addEventListener("keydown", onKeyDown);
 		return () => document.removeEventListener("keydown", onKeyDown);
-	}, [onClose, id]);
+	}, [onClose, state]);
+
+	if (!state) return null;
+	const { title, message, confirmText, cancelText, id } = state;
+
 	return (
 		<div className="confirm-overlay" role="dialog" aria-modal="true">
 			<div
@@ -125,7 +128,9 @@ export const ConfirmProvider: React.FC<{ children: React.ReactNode }> = ({
 			if (prevActiveRef.current) {
 				try {
 					prevActiveRef.current.focus();
-				} catch {}
+				} catch {
+					// Ignore focus errors
+				}
 			}
 			return null;
 		});


### PR DESCRIPTION
Separate ClearDataButton from ErrorBoundary to avoid conditional hook usage inside render. Move confirm logic into this standalone component, call handleClearStorage then reload on confirm, and replace the inline component with a simple element. Also add a safe catch comment when localStorage.removeItem throws.

Improve ConfirmOverlayBase effect and rendering order: check for null state early in the effect dependencies, move the guard so the effect depends on state, and defer destructuring of state until after the effect. Add a safe catch comment around focus restore to ignore errors.